### PR TITLE
Dsp-12  feat: 배당금 포트폴리오 생성 로직

### DIFF
--- a/src/main/java/com/shinhan/bullsandbears/domain/Duration.java
+++ b/src/main/java/com/shinhan/bullsandbears/domain/Duration.java
@@ -4,16 +4,18 @@ import lombok.Getter;
 
 @Getter
 public enum Duration {
-
-  SIXTH_MONTHS("6개월"),
-  ONE_YEAR("1년"),
-  TWO_YEARS("2년"),
-  THREE_YEARS("3년");
+  TWO_MONTHS("2개월", 60),
+  SIXTH_MONTHS("6개월", 180),
+  ONE_YEAR("1년", 365),
+  TWO_YEARS("2년", 730),
+  THREE_YEARS("3년", 1095);
 
   private final String label;
-
-  Duration(String label) {
+  private final int days;
+  
+  Duration(String label, int days) {
     this.label = label;
+    this.days = days;
   }
 
 }

--- a/src/main/java/com/shinhan/bullsandbears/domain/Duration.java
+++ b/src/main/java/com/shinhan/bullsandbears/domain/Duration.java
@@ -12,7 +12,7 @@ public enum Duration {
 
   private final String label;
   private final int days;
-  
+
   Duration(String label, int days) {
     this.label = label;
     this.days = days;

--- a/src/main/java/com/shinhan/bullsandbears/domain/StockReportHistory.java
+++ b/src/main/java/com/shinhan/bullsandbears/domain/StockReportHistory.java
@@ -1,6 +1,9 @@
 package com.shinhan.bullsandbears.domain;
 
 import javax.persistence.*;
+
+import com.shinhan.bullsandbears.report.Report;
+import com.shinhan.bullsandbears.stock.StockMaster;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/shinhan/bullsandbears/domain/StockReportHistory.java
+++ b/src/main/java/com/shinhan/bullsandbears/domain/StockReportHistory.java
@@ -26,10 +26,15 @@ public class StockReportHistory {
   @JoinColumn(name="report_id")
   private Report report;
 
+  private Integer stockGroup;   // 주식 리스트 그룹
+  private Integer stockUnits;   // 하나의 주식당 구매한 개수
+
   @Builder
-  public StockReportHistory(StockMaster stockMaster, Report report){
+  public StockReportHistory(StockMaster stockMaster, Report report, Integer stockUnits, Integer stockGroup){
     this.stockMaster = stockMaster;
     this.report = report;
+    this.stockUnits = stockUnits;
+    this.stockGroup = stockGroup;
   }
 
 }

--- a/src/main/java/com/shinhan/bullsandbears/domain/User.java
+++ b/src/main/java/com/shinhan/bullsandbears/domain/User.java
@@ -16,6 +16,10 @@ import java.util.List;
 public class User {
 
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long id;
+
   private String email;
 
   private String name;
@@ -23,6 +27,5 @@ public class User {
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<UserReportHistory> userReportHistoryList = new ArrayList<>();
-
 
 }

--- a/src/main/java/com/shinhan/bullsandbears/domain/UserReportHistory.java
+++ b/src/main/java/com/shinhan/bullsandbears/domain/UserReportHistory.java
@@ -1,5 +1,6 @@
 package com.shinhan.bullsandbears.domain;
 
+import com.shinhan.bullsandbears.report.Report;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/shinhan/bullsandbears/report/Report.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/Report.java
@@ -1,10 +1,14 @@
-package com.shinhan.bullsandbears.domain;
+package com.shinhan.bullsandbears.report;
 
+import com.shinhan.bullsandbears.domain.Duration;
+import com.shinhan.bullsandbears.domain.StockReportHistory;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,11 +22,20 @@ public class Report {
   @Column(name = "report_id")
   private Long id;
 
+  @Enumerated(EnumType.STRING)
   private Duration duration;
-  private Integer amount;
+
+  private BigDecimal amount;
   private LocalDate createdAt;
 
   @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<UserReportHistory> userReportHistoryList = new ArrayList<>();
+  private List<StockReportHistory> stockReportHistoryList = new ArrayList<>();
+
+  @Builder
+  public Report (Duration duration, BigDecimal amount, LocalDate createdAt){
+    this.duration = duration;
+    this.amount = amount;
+    this.createdAt = createdAt;
+  }
 
 }

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportController.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportController.java
@@ -1,0 +1,23 @@
+package com.shinhan.bullsandbears.report;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+public class ReportController {
+  private final ReportService reportService;
+
+  @PostMapping("/")
+  public ResponseEntity<ReportDto.CreateResponse> createReport(@RequestBody ReportDto.CreateRequest reportDto) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(reportService.createReport(reportDto));
+  }
+
+
+}

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportController.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportController.java
@@ -3,10 +3,7 @@ package com.shinhan.bullsandbears.report;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +13,6 @@ public class ReportController {
 
   @PostMapping("/")
   public ResponseEntity<ReportDto.CreateResponse> createReport(@RequestBody ReportDto.CreateRequest reportDto) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(reportService.createReport(reportDto));
+    return ResponseEntity.status(HttpStatus.OK).body(reportService.createReport(reportDto));
   }
-
-
 }

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportDto.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportDto.java
@@ -1,0 +1,29 @@
+package com.shinhan.bullsandbears.report;
+import com.shinhan.bullsandbears.domain.Duration;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class ReportDto {
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor
+  public static class CreateRequest {
+    private BigDecimal amount;
+    private Duration duration;
+  }
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor
+  public static class CreateResponse {
+    private Long reportId;
+    private LocalDate createdAt;
+
+    public CreateResponse(Report report) {
+      this.reportId = report.getId();
+      this.createdAt = report.getCreatedAt();
+
+    }
+  }
+}

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportDto.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportDto.java
@@ -26,4 +26,5 @@ public class ReportDto {
 
     }
   }
+
 }

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportRepository.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.shinhan.bullsandbears.report;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportService.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportService.java
@@ -1,0 +1,8 @@
+package com.shinhan.bullsandbears.report;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ReportService {
+  ReportDto.CreateResponse createReport(ReportDto.CreateRequest request);
+}

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportServiceImpl.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportServiceImpl.java
@@ -29,8 +29,8 @@ public class ReportServiceImpl implements ReportService {
     BigDecimal amount = request.getAmount();
 
     List<StockMaster> stocks = stockRepository.findAll();
-
     List<StockMaster> calculatedStocks = calculateLogic(stocks, duration.getDays());
+    List<StockMaster> optimalStocks = findOptimalStockCombination(calculatedStocks, amount);
 
     Report report = Report.builder()
             .duration(duration)
@@ -38,7 +38,7 @@ public class ReportServiceImpl implements ReportService {
             .createdAt(LocalDate.now())
             .build();
 
-    calculatedStocks.forEach(stock -> createStockReport(stock, report));
+    optimalStocks.forEach(stock -> createStockReport(stock, report));
 
     return new ReportDto.CreateResponse(report);
   }
@@ -84,5 +84,53 @@ public class ReportServiceImpl implements ReportService {
             .sorted(dividendComparator)
             .limit(10)
             .collect(Collectors.toList());
+  }
+
+  public List<StockMaster> findOptimalStockCombination(List<StockMaster> stocks, BigDecimal amount) {
+
+    int n = stocks.size();
+    List<List<BigDecimal>> dp = new ArrayList<>(n + 1);
+
+
+    for (int i = 0; i <= n; i++) {
+      List<BigDecimal> row = new ArrayList<>(amount.intValue() + 1);
+      for (int j = 0; j <= amount.intValue(); j++) {
+        row.add(BigDecimal.ZERO);
+      }
+      dp.add(row);
+    }
+
+    for (int i = 1; i <= n; i++) {
+      StockMaster stock = stocks.get(i - 1);
+      BigDecimal price = stock.getPrice();
+      BigDecimal dividend = stock.getDividendAmount();
+
+      for (int j = 0; j <= amount.intValue(); j++) {
+        BigDecimal maxWithoutSelect = dp.get(i - 1).get(j);
+
+        dp.get(i).set(j, maxWithoutSelect);
+
+        for (int k = 1; k * price.intValue() <= j; k++) {
+          BigDecimal selectMultipleTimes = dp.get(i - 1).get(j - k * price.intValue())
+                  .add(BigDecimal.valueOf(k).multiply(dividend));
+          
+          if (selectMultipleTimes.compareTo(dp.get(i).get(j)) > 0) {
+            dp.get(i).set(j, selectMultipleTimes);
+          }
+        }
+      }
+
+    }
+
+    int j = amount.intValue();
+    List<StockMaster> selectedStocks = new ArrayList<>();
+    for (int i = n; i > 0 && j > 0; i--) {
+      if (!dp.get(i).get(j).equals(dp.get(i - 1).get(j))) {
+        selectedStocks.add(stocks.get(i - 1));
+        j -= stocks.get(i - 1).getPrice().intValue();
+      }
+    }
+
+    return selectedStocks;
   }
 }

--- a/src/main/java/com/shinhan/bullsandbears/report/ReportServiceImpl.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/ReportServiceImpl.java
@@ -1,0 +1,88 @@
+package com.shinhan.bullsandbears.report;
+
+import com.shinhan.bullsandbears.domain.Duration;
+import com.shinhan.bullsandbears.stock.StockMaster;
+import com.shinhan.bullsandbears.domain.StockReportHistory;
+import com.shinhan.bullsandbears.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportServiceImpl implements ReportService {
+
+  private final StockRepository stockRepository;
+  private final StockReportHistoryRepository stockReportHistoryRepository;
+
+  @Override
+  @Transactional
+  public ReportDto.CreateResponse createReport(ReportDto.CreateRequest request) {
+
+    Duration duration = request.getDuration();
+    BigDecimal amount = request.getAmount();
+
+    List<StockMaster> stocks = stockRepository.findAll();
+
+    List<StockMaster> calculatedStocks = calculateLogic(stocks, duration.getDays());
+
+    Report report = Report.builder()
+            .duration(duration)
+            .amount(amount)
+            .createdAt(LocalDate.now())
+            .build();
+
+    calculatedStocks.forEach(stock -> createStockReport(stock, report));
+
+    return new ReportDto.CreateResponse(report);
+  }
+
+  @Transactional
+  public void createStockReport(StockMaster stock, Report report) {
+
+    stockReportHistoryRepository.save(
+            StockReportHistory.builder()
+                    .stockMaster(stock)
+                    .report(report)
+                    .build()
+    );
+  }
+
+  public List<StockMaster> calculateLogic(List<StockMaster> stocks, Integer duration) {
+
+    List<StockMaster> filteredByDividendRecordDateStocks = filterByDividendRecordDate(stocks, LocalDate.now());
+    List<StockMaster> filteredStocksByPurchaseDate = filterStocksByPurchaseDate(filteredByDividendRecordDateStocks,LocalDate.now());
+
+    List<StockMaster> sortedStocks = sortedByDividendPerShareRatio(filteredStocksByPurchaseDate);
+
+    return sortedStocks;
+  }
+
+  public List<StockMaster> filterByDividendRecordDate(List<StockMaster> stocks, LocalDate currentDate){
+
+    return stocks.stream()
+            .filter(stock -> stock.getDividendRecordDate().isAfter(currentDate))
+            .collect(Collectors.toList());
+  }
+
+  public List<StockMaster> filterStocksByPurchaseDate(List<StockMaster> stocks, LocalDate purchaseDate) {
+    return stocks.stream()
+            .filter(stock -> purchaseDate.isBefore(stock.getDividendRecordDate().minusDays(1)))
+            .collect(Collectors.toList());
+  }
+
+  public List<StockMaster> sortedByDividendPerShareRatio(List<StockMaster> stocks) {
+    Comparator<StockMaster> dividendComparator = Comparator.comparing(StockMaster::getDividendPerShareRatio).reversed();
+
+    return stocks.stream()
+            .sorted(dividendComparator)
+            .limit(10)
+            .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/shinhan/bullsandbears/report/StockReportHistoryRepository.java
+++ b/src/main/java/com/shinhan/bullsandbears/report/StockReportHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.shinhan.bullsandbears.report;
+
+import com.shinhan.bullsandbears.domain.StockReportHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StockReportHistoryRepository extends JpaRepository<StockReportHistory, Long> {
+
+}

--- a/src/main/java/com/shinhan/bullsandbears/stock/StockMaster.java
+++ b/src/main/java/com/shinhan/bullsandbears/stock/StockMaster.java
@@ -1,5 +1,6 @@
-package com.shinhan.bullsandbears.domain;
+package com.shinhan.bullsandbears.stock;
 
+import com.shinhan.bullsandbears.domain.StockReportHistory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,9 +26,10 @@ public class StockMaster {
   private String stockMarket;      // 시장명
   private BigDecimal price;        // 주식 가격
   private BigDecimal dividendAmount;      // 주당 배당금
-  private BigDecimal dividendYieldRate;   // 시가 수익률
+  private BigDecimal DividendPerShareRatio;   // 시가 배당률
   private String stockType;        // 주식 종류
-  private Date dividendPaymentDate;       // 배당금 지급일
+  private LocalDate dividendRecordDate;       // 배당금 기준일
+  private LocalDate dividendPaymentDate;       // 배당금 지급일
   private BigDecimal faceValue;    // 액면가
   private LocalDate savedAt;       // 데이터 저장 일자
   private LocalDate updatedAt;     // 데이터 수정 일자

--- a/src/main/java/com/shinhan/bullsandbears/stock/StockMaster.java
+++ b/src/main/java/com/shinhan/bullsandbears/stock/StockMaster.java
@@ -23,14 +23,12 @@ public class StockMaster {
   private Long id;
 
   private String stockName;        // 종목명
-  private String stockMarket;      // 시장명
   private BigDecimal price;        // 주식 가격
   private BigDecimal dividendAmount;      // 주당 배당금
   private BigDecimal DividendPerShareRatio;   // 시가 배당률
   private String stockType;        // 주식 종류
   private LocalDate dividendRecordDate;       // 배당금 기준일
   private LocalDate dividendPaymentDate;       // 배당금 지급일
-  private BigDecimal faceValue;    // 액면가
   private LocalDate savedAt;       // 데이터 저장 일자
   private LocalDate updatedAt;     // 데이터 수정 일자
 

--- a/src/main/java/com/shinhan/bullsandbears/stock/StockRepository.java
+++ b/src/main/java/com/shinhan/bullsandbears/stock/StockRepository.java
@@ -1,0 +1,9 @@
+package com.shinhan.bullsandbears.stock;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StockRepository extends JpaRepository<StockMaster, Long> {
+
+}


### PR DESCRIPTION
## 💡 Motivation
+ 1차로 현재 매수 가능한 주식을 필터링했습니다.
    + (1) 배당 기준일 기준으로 필터링  (기한안에 배당을 보장받기 위해선 배당 기준일이 현재 날짜 이후에 존재해야 합니다)
    + (2) 주식 매수 날짜 기준으로 필터링 (배당을 받으려면 배당 기준일 2일 전에 매수해야 합니다)
+ 2차로 시가 배당률이 높은 순으로 정렬해서 10개만 추출했습니다.
+ 3차로 10개의 주식을 이용해서 최대의 배당금을 얻을수 있는 조합을 만들었습니다.  
    + backtracking을 이용하여 최적의 해를 찾아내는 알고리즘을 구현했습니다.
    + 동일한 배당금을 얻을 수 있는 주식 조합이 여러개 나올 수 있다는 부분을 고려하여 List형태로 반환했습니다.

## 🗝️ Key Changes

+ User 엔티티에서 기본키를 email에서 id로 바꿨습니다.
+ StockReportHistory 엔티티에 주식 매수 개수를 명시하는 필드를 추가하였습니다.
+ 기획과 피그마 상에서는 5개의 주식만 나오도록 되어있는 걸로 알고 있는데,  해당 로직에서는 시가 배당률이 높은 순으로 정렬해서 10개를 추출했습니다. (바뀔 가능성도 있습니다)


## 🙌 To Reviewers
<img width="707" alt="image" src="https://github.com/bulls-and-bears/server/assets/69106295/9bad6d8c-6fd5-4627-8313-6680e570c365">

- ERD 변경이 있었습니다. 다들 참고해주세요!
